### PR TITLE
Fix example use of HMAC in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,8 +80,7 @@ Example VCL::
 	import digest;
 
 	sub vcl_recv {
-		if (digest.hmac_sha256("key",req.http.x-some-header) !=
-			digest.hmac_sha256("key",req.http.x-some-header-signed))
+		if (digest.hmac_sha256("key",req.http.x-data) != req.http.x-data-sig)
 		{
 			return (synth(401, "Naughty user!"));
 		}


### PR DESCRIPTION
Applying hmac to both sides of equation does not make sense as it is then almost the same as checking if both headers are equal.

I've also changed the x-some-header to x-data so that it is consistent with later examples.