### PR TITLE
Replace WS_Reserve() with WS_ReserveAll().

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
 before_install:
   - sudo apt-get update -q
   - sudo apt-get install -qq apt-transport-https libmhash-dev python-docutils
-  - curl -s https://packagecloud.io/install/repositories/varnishcache/varnish60lts/script.deb.sh | sudo bash
+  - curl -s https://packagecloud.io/install/repositories/varnishcache/varnish63/script.deb.sh | sudo bash
   - sudo apt-get -q update
   - sudo apt-get install varnish varnish-dev
   - ./autogen.sh

--- a/src/vmod_digest.c
+++ b/src/vmod_digest.c
@@ -348,7 +348,7 @@ VPFX(base64_generic)(VRT_CTX, enum alphabets a, const char *msg, int is_hex)
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
 
-	u = WS_Reserve(ctx->ws,0);
+	u = WS_ReserveAll(ctx->ws);
 	if (u <= 0) {
 		VRT_fail(ctx, "digest.base64_generic() Error: Out of Workspace");
 		WS_Release(ctx->ws,0);
@@ -372,7 +372,7 @@ VPFX(base64_decode_generic)(VRT_CTX, enum alphabets a, const char *msg)
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
 
-	u = WS_Reserve(ctx->ws,0);
+	u = WS_ReserveAll(ctx->ws);
 	if (u <= 0) {
 		VRT_fail(ctx, "digest.base64_decode_generic() Error: "
 		    "Out of Workspace");


### PR DESCRIPTION
Making the VMOD compatible with Varnish 6.3.0 (without deprecation warnings).