### PR TITLE
don't redefine the workspace size

### DIFF
--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -2,7 +2,7 @@ varnishtest "Test digest vmod out of workspace"
 
 server s1 { } -start
 
-varnish v1 -arg "-p workspace_client=9k" -vcl+backend {
+varnish v1 -vcl+backend {
 	import digest from "${vmod_topbuild}/src/.libs/libvmod_digest.so";
 	import vtc;
 


### PR DESCRIPTION
it's not needed by the test, and
8869801544c52b59812ff7272fe753cc4569cd91 in varnish-cache breaks the 9k
limit