### PR TITLE
Set vsl_buffer in test02 to avoid test panic

### DIFF
--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -2,7 +2,7 @@ varnishtest "Test digest vmod out of workspace"
 
 server s1 { } -start
 
-varnish v1 -arg "-p workspace_client=9k" -vcl+backend {
+varnish v1 -arg "-p workspace_client=9k -p vsl_buffer=4k" -vcl+backend {
 	import digest from "${vmod_topbuild}/src/.libs/libvmod_digest.so";
 	import vtc;
 


### PR DESCRIPTION
Whenever I try to install this vmod on v7.x with [install-vmod](https://github.com/varnish/toolbox/tree/master/install-vmod) test02.vtc fails on the following assertion:
<details>
<summary>Varnishtest output</summary>

```
**** dT    0.000
*    top   TEST ../src/tests/test02.vtc starting
**** top   extmacro def pwd=/tmp/module_to_build/src
**** top   extmacro def date(...)
**** top   extmacro def string(...)
**** top   extmacro def varnishd=/usr/sbin/varnishd
**** top   extmacro def vmod_topbuild=/tmp/module_to_build
**** top   extmacro def localhost=127.0.0.1
**** top   extmacro def bad_backend=127.0.0.1:39449
**** top   extmacro def listen_addr=127.0.0.1:0
**** top   extmacro def bad_ip=192.0.2.255
**** top   macro def testdir=/tmp/module_to_build/src/../src/tests
**** top   macro def tmpdir=/tmp/vtc.2596.40b16eae
**   top   === varnishtest "Test digest vmod out of workspace"
*    top   VTEST Test digest vmod out of workspace
**   top   === server s1 { } -start
**   s1    Starting server
**** s1    macro def s1_addr=127.0.0.1
**** s1    macro def s1_port=33071
**** s1    macro def s1_sock=127.0.0.1:33071
*    s1    Listen on 127.0.0.1:33071
**   top   === varnish v1 -arg "-p workspace_client=9k" -vcl+backend {
**   s1    Started on 127.0.0.1:33071 (1 iterations)
**** dT    0.001
**   v1    Launch
***  v1    CMD: cd ${pwd} && exec varnishd  -d -n /tmp/vtc.2596.40b16eae/v1 -l 2m -p auto_restart=off -p syslog_cli_traffic=off -p thread_pool_min=10 -p debug=+vtc_mode -p vsl_mask=+Debug -p h2_initial_window_size=1m -p h2_rx_window_low_water=64k -a '127.0.0.1:0' -M '127.0.0.1 36051' -P /tmp/vtc.2596.40b16eae/v1/varnishd.pid  -p workspace_client=9k
***  v1    CMD: cd /tmp/module_to_build/src && exec varnishd  -d -n /tmp/vtc.2596.40b16eae/v1 -l 2m -p auto_restart=off -p syslog_cli_traffic=off -p thread_pool_min=10 -p debug=+vtc_mode -p vsl_mask=+Debug -p h2_initial_window_size=1m -p h2_rx_window_low_water=64k -a '127.0.0.1:0' -M '127.0.0.1 36051' -P /tmp/vtc.2596.40b16eae/v1/varnishd.pid  -p workspace_client=9k
***  v1    PID: 2627
**** v1    macro def v1_pid=2627
**** v1    macro def v1_name=/tmp/vtc.2596.40b16eae/v1
**** dT    0.007
***  v1    debug|Debug: Version: varnish-7.1.1 revision 7cee1c581bead20e88d101ab3d72afb29f14d87a
***  v1    debug|Debug: Platform: Linux,5.15.0-46-generic,x86_64,-junix,-sdefault,-sdefault,-hcritbit
***  v1    debug|200 318     
***  v1    debug|-----------------------------
***  v1    debug|Varnish Cache CLI 1.0
***  v1    debug|-----------------------------
***  v1    debug|Linux,5.15.0-46-generic,x86_64,-junix,-sdefault,-sdefault,-hcritbit
***  v1    debug|varnish-7.1.1 revision 7cee1c581bead20e88d101ab3d72afb29f14d87a
***  v1    debug|
***  v1    debug|Type 'help' for command list.
***  v1    debug|Type 'quit' to close CLI session.
***  v1    debug|Type 'start' to launch worker process.
***  v1    debug|
**** dT    0.106
**** v1    CLIPOLL 1 0x1 0x0 0x0
***  v1    CLI connection fd = 7
***  v1    CLI RX  107
**** v1    CLI RX|xvrbcoedybasdksrwxrdvhtgperrbrci
**** v1    CLI RX|
**** v1    CLI RX|Authentication required.
**** v1    CLI TX|auth ca892238383f5f1b689fc53d75a9b785a0b3d9b356b913ce08a31dbeb90d0c77
***  v1    CLI RX  200
**** v1    CLI RX|-----------------------------
**** v1    CLI RX|Varnish Cache CLI 1.0
**** v1    CLI RX|-----------------------------
**** v1    CLI RX|Linux,5.15.0-46-generic,x86_64,-junix,-sdefault,-sdefault,-hcritbit
**** v1    CLI RX|varnish-7.1.1 revision 7cee1c581bead20e88d101ab3d72afb29f14d87a
**** v1    CLI RX|
**** v1    CLI RX|Type 'help' for command list.
**** v1    CLI RX|Type 'quit' to close CLI session.
**** v1    CLI RX|Type 'start' to launch worker process.
**** v1    CLI TX|vcl.inline vcl1 << %XJEIFLH|)Xspa8P
**** v1    CLI TX|vcl 4.1;
**** v1    CLI TX|backend s1 { .host = "127.0.0.1"; .port = "33071"; }
**** v1    CLI TX|
**** v1    CLI TX|
**** v1    CLI TX|\timport digest from "/tmp/module_to_build/src/.libs/libvmod_digest.so";
**** v1    CLI TX|\timport vtc;
**** v1    CLI TX|
**** v1    CLI TX|\tsub vcl_recv {
**** v1    CLI TX|\t\tvtc.workspace_alloc(client, -5);
**** v1    CLI TX|\t\tif (req.url == "/hmac_sha256") {
**** v1    CLI TX|\t\t\tset req.http.hmac_sha256 = digest.hmac_sha256("key", "The quick brown fox jumps over the lazy dog");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|
**** v1    CLI TX|\t\tif (req.url == "/hmac_sha1") {
**** v1    CLI TX|\t\t\tset req.http.hmac_sha1 = digest.hmac_sha1("key", "The quick brown fox jumps over the lazy dog");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|
**** v1    CLI TX|\t\tif (req.url == "/hmac_md5") {
**** v1    CLI TX|\t\t\tset req.http.md5 = digest.hmac_md5("key", "The quick brown fox jumps over the lazy dog");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|
**** v1    CLI TX|\t\tif (req.url == "/base64") {
**** v1    CLI TX|\t\t\tset req.http.base64 = digest.base64("TeSTTeSTTeST");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|
**** v1    CLI TX|\t\tif (req.url == "/base64_hex") {
**** v1    CLI TX|\t\t\tset req.http.base64_hex = digest.base64_hex("0x54655354");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|
**** v1    CLI TX|\t\tif (req.url == "/base64_decode") {
**** v1    CLI TX|\t\t\tset req.http.base64_decode = digest.base64_decode("zprOsc67z47PgiDOv8+Bzq/Pg86xz4TOtQ==");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|
**** v1    CLI TX|\t\tif (req.url == "/base64url") {
**** v1    CLI TX|\t\t\tset req.http.base64url = digest.base64url("Interesting!");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|
**** v1    CLI TX|\t\tif (req.url == "/base64url_hex") {
**** v1    CLI TX|\t\t\tset req.http.base64url = digest.base64url("496E746572657374696E6721");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|
**** v1    CLI TX|\t\tif (req.url == "/base64url_decode") {
**** v1    CLI TX|\t\t\tset req.http.base64url_decode = digest.base64url_decode("MHg4MDA3MDcxMzQ2M2U3NzQ5YjkwYzJkYzI0OTExZTI3NQ");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|
**** v1    CLI TX|\t\tif (req.url == "/hash_sha1") {
**** v1    CLI TX|\t\t\tset req.http.hash_sha1 = digest.hash_sha1("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|
**** v1    CLI TX|\t\tif (req.url == "/hash_md4") {
**** v1    CLI TX|\t\t\tset req.http.hash_md4 = digest.hash_md4("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|
**** v1    CLI TX|\t\tif (req.url == "/hash_whirlpool") {
**** v1    CLI TX|\t\t\tset req.http.hash_whirlpool = digest.hash_whirlpool("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
**** v1    CLI TX|\t\t}
**** v1    CLI TX|\t}
**** v1    CLI TX|
**** v1    CLI TX|
**** v1    CLI TX|%XJEIFLH|)Xspa8P
**** dT    0.206
***  v1    vsl|No VSL chunk found (child not started ?)
**** dT    0.279
***  v1    CLI RX  200
**** v1    CLI RX|VCL compiled.
**** v1    CLI TX|vcl.use vcl1
***  v1    CLI RX  200
**** v1    CLI RX|VCL 'vcl1' now active
**   v1    Start
**** v1    CLI TX|start
**** dT    0.280
***  v1    debug|Debug: Child (2758) Started
**** dT    0.302
***  v1    debug|Child launched OK
**** dT    0.303
***  v1    CLI RX  200
***  v1    wait-running
**** v1    CLI TX|status
***  v1    debug|Info: Child (2758) said Child starts
***  v1    CLI RX  200
**** v1    CLI RX|Child in state running
**** v1    CLI TX|debug.listen_address
***  v1    CLI RX  200
**** v1    CLI RX|a0 127.0.0.1 46569
**** v1    CLI TX|debug.xid 999
***  v1    CLI RX  200
**** v1    CLI RX|XID is 999 chunk 1
**** v1    CLI TX|debug.listen_address
***  v1    CLI RX  200
**** v1    CLI RX|a0 127.0.0.1 46569
**   v1    Listen on 127.0.0.1 46569
**** v1    macro def v1_addr=127.0.0.1
**** v1    macro def v1_port=46569
**** v1    macro def v1_sock=127.0.0.1:46569
**** v1    macro def v1_a0_addr=127.0.0.1
**** v1    macro def v1_a0_port=46569
**** v1    macro def v1_a0_sock=127.0.0.1:46569
**** dT    0.307
**** v1    vsl|          0 CLI             - Rd vcl.load "vcl1" vcl_vcl1.1663338007.306742/vgc.so 1auto
**** v1    vsl|          0 CLI             - Wr 200 52 Loaded "vcl_vcl1.1663338007.306742/vgc.so" as "vcl1"
**** v1    vsl|          0 CLI             - Rd vcl.use "vcl1"
**** v1    vsl|          0 CLI             - Wr 200 0 
**** v1    vsl|          0 CLI             - Rd start
**** v1    vsl|          0 Debug           - sockopt: Setting SO_LINGER for a0=127.0.0.1:46569
**** v1    vsl|          0 Debug           - sockopt: Setting SO_KEEPALIVE for a0=127.0.0.1:46569
**** v1    vsl|          0 Debug           - sockopt: Setting SO_SNDTIMEO for a0=127.0.0.1:46569
**** v1    vsl|          0 Debug           - sockopt: Setting SO_RCVTIMEO for a0=127.0.0.1:46569
**** v1    vsl|          0 Debug           - sockopt: Setting TCP_NODELAY for a0=127.0.0.1:46569
**** v1    vsl|          0 Debug           - sockopt: Setting TCP_KEEPIDLE for a0=127.0.0.1:46569
**** v1    vsl|          0 Debug           - sockopt: Setting TCP_KEEPCNT for a0=127.0.0.1:46569
**** v1    vsl|          0 Debug           - sockopt: Setting TCP_KEEPINTVL for a0=127.0.0.1:46569
**** v1    vsl|          0 CLI             - Wr 200 0 
**** v1    vsl|          0 CLI             - Rd debug.listen_address 
**** v1    vsl|          0 CLI             - Wr 200 19 a0 127.0.0.1 46569

**** v1    vsl|          0 CLI             - Rd debug.xid 999 
**** v1    vsl|          0 CLI             - Wr 200 18 XID is 999 chunk 1
**** v1    vsl|          0 CLI             - Rd debug.listen_address 
**** v1    vsl|          0 CLI             - Wr 200 19 a0 127.0.0.1 46569

**** dT    0.403
**   top   === logexpect l1 -v v1 -i VCL_Error {
**   l1    === expect * * *	"digest.hmac_generic() Error: Out of Workspace"
**   l1    === expect * * *	"digest.hmac_generic() Error: Out of Workspace"
**   l1    === expect * * *	"digest.hmac_generic() Error: Out of Workspace"
**   l1    === expect * * *	"digest.base64_generic() Error: Out of Workspac...
**   l1    === expect * * *	"digest.base64_generic() Error: Out of Workspac...
**   l1    === expect * * *	"digest.base64_decode_generic() Error: Out of W...
**   l1    === expect * * *	"digest.base64_decode_generic() Error: Out of W...
**   l1    === expect * * *	"digest.hash_generic() Error: Out of Workspace"
**   l1    === expect * * *	"digest.hash_generic() Error: Out of Workspace"
**   l1    === expect * * *	"digest.hash_generic() Error: Out of Workspace"
**   top   === client c1 {
**   c1    Starting client
**** l1    begin|
***  l1    test | expect * * * digest.hmac_generic() Error: Out of Workspace
**   c1    Waiting for client
**   c1    Started on 127.0.0.1:46569 (1 iterations)
***  c1    Connect to 127.0.0.1:46569
***  c1    connected fd 22 from 127.0.0.1 55750 to 127.0.0.1:46569
**   c1    === txreq -url "/hmac_sha256"
**** c1    txreq|GET /hmac_sha256 HTTP/1.1\r
**** c1    txreq|Host: 127.0.0.1\r
**** c1    txreq|\r
**   c1    === rxresp
**** dT    0.404
---- c1    HTTP rx failed (fd:22 read: Connection reset by peer)
*    top   RESETTING after ../src/tests/test02.vtc
**   l1    Waiting for logexp
**** dT    0.405
**   s1    Waiting for server (4/-1)
**   v1    Wait
**** v1    CLI TX|panic.show
**** dT    0.407
**** v1    vsl|       1000 Begin           c sess 0 HTTP/1
**** v1    vsl|       1000 SessOpen        c 127.0.0.1 55750 a0 127.0.0.1 46569 1663338007.603840 22
**** v1    vsl|       1000 Debug           c sockopt: SO_LINGER may be inherited for a0=127.0.0.1:46569
**** v1    vsl|       1000 Debug           c sockopt: SO_KEEPALIVE may be inherited for a0=127.0.0.1:46569
**** v1    vsl|       1000 Debug           c sockopt: SO_SNDTIMEO may be inherited for a0=127.0.0.1:46569
**** v1    vsl|       1000 Debug           c sockopt: SO_RCVTIMEO may be inherited for a0=127.0.0.1:46569
**** v1    vsl|       1000 Debug           c sockopt: TCP_NODELAY may be inherited for a0=127.0.0.1:46569
**** v1    vsl|       1000 Debug           c sockopt: TCP_KEEPIDLE may be inherited for a0=127.0.0.1:46569
**** v1    vsl|       1000 Debug           c sockopt: TCP_KEEPCNT may be inherited for a0=127.0.0.1:46569
**** v1    vsl|       1000 Debug           c sockopt: TCP_KEEPINTVL may be inherited for a0=127.0.0.1:46569
**** dT    0.504
***  v1    debug|Error: Child (2758) died signal=6
**** dT    0.505
***  v1    debug|Error: Child (2758) Panic at: Fri, 16 Sep 2022 14:20:07 GMT
***  v1    debug|Assert error in Req_New(), cache/cache_req.c line 170:
***  v1    debug|  Condition(p < e) not true.
***  v1    debug|version = varnish-7.1.1 revision 7cee1c581bead20e88d101ab3d72afb29f14d87a, vrt api = 15.0
***  v1    debug|ident = Linux,5.15.0-46-generic,x86_64,-junix,-sdefault,-sdefault,-hcritbit,epoll
***  v1    debug|now = 259739.806423 (mono), 1663338007.603864 (real)
***  v1    debug|Backtrace:
***  v1    debug|  0x55cb130c372c: varnishd(+0x5972c) [0x55cb130c372c]
***  v1    debug|  0x55cb1313eed8: varnishd(VAS_Fail+0x18) [0x55cb1313eed8]
***  v1    debug|  0x55cb130c61ab: varnishd(Req_New+0x2bb) [0x55cb130c61ab]
***  v1    debug|  0x55cb13095e0c: varnishd(+0x2be0c) [0x55cb13095e0c]
***  v1    debug|  0x55cb130ea0f2: varnishd(+0x800f2) [0x55cb130ea0f2]
***  v1    debug|  0x55cb130ea684: varnishd(+0x80684) [0x55cb130ea684]
***  v1    debug|  0x7f7bdf7d1ea7: /lib/x86_64-linux-gnu/libpthread.so.0(+0x7ea7) [0x7f7bdf7d1ea7]
***  v1    debug|  0x7f7bdf6f1aef: /lib/x86_64-linux-gnu/libc.so.6(clone+0x3f) [0x7f7bdf6f1aef]
***  v1    debug|argv = {
***  v1    debug|  [0] = \"varnishd\",
***  v1    debug|  [1] = \"-d\",
***  v1    debug|  [2] = \"-n\",
***  v1    debug|  [3] = \"/tmp/vtc.2596.40b16eae/v1\",
***  v1    debug|  [4] = \"-l\",
***  v1    debug|  [5] = \"2m\",
***  v1    debug|  [6] = \"-p\",
***  v1    debug|  [7] = \"auto_restart=off\",
***  v1    debug|  [8] = \"-p\",
***  v1    debug|  [9] = \"syslog_cli_traffic=off\",
***  v1    debug|  [10] = \"-p\",
***  v1    debug|  [11] = \"thread_pool_min=10\",
***  v1    debug|  [12] = \"-p\",
***  v1    debug|  [13] = \"debug=+vtc_mode\",
***  v1    debug|  [14] = \"-p\",
***  v1    debug|  [15] = \"vsl_mask=+Debug\",
***  v1    debug|  [16] = \"-p\",
***  v1    debug|  [17] = \"h2_initial_window_size=1m\",
***  v1    debug|  [18] = \"-p\",
***  v1    debug|  [19] = \"h2_rx_window_low_water=64k\",
***  v1    debug|  [20] = \"-a\",
***  v1    debug|  [21] = \"127.0.0.1:0\",
***  v1    debug|  [22] = \"-M\",
***  v1    debug|  [23] = \"127.0.0.1 36051\",
***  v1    debug|  [24] = \"-P\",
***  v1    debug|  [25] = \"/tmp/vtc.2596.40b16eae/v1/varnishd.pid\",
***  v1    debug|  [26] = \"-p\",
***  v1    debug|  [27] = \"workspace_client=9k\",
***  v1    debug|}
***  v1    debug|pthread.self = 0x7f7bdd0fe700
***  v1    debug|pthread.name = (cache-worker)
***  v1    debug|pthread.attr = {
***  v1    debug|  guard = 4096,
***  v1    debug|  stack_bottom = 0x7f7bdd0eb000,
***  v1    debug|  stack_top = 0x7f7bdd0ff000,
***  v1    debug|  stack_size = 81920,
***  v1    debug|}
***  v1    debug|thr.req = NULL
***  v1    debug|thr.busyobj = NULL
***  v1    debug|thr.worker = 0x7f7bdd0fc590 {
***  v1    debug|  ws = 0x7f7bdd0fc618 {
***  v1    debug|    id = \"wrk\",
***  v1    debug|    {s, f, r, e} = {0x7f7bdd0fbb30, +0, +152, +2040},
***  v1    debug|  },
***  v1    debug|  VCL::method = none,
***  v1    debug|  vmods = {
***  v1    debug|    digest = {0x7f7bdf0d30e0, Varnish 7.1.1 7cee1c581bead20e88d101ab3d72afb29f14d87a, 0.0},
***  v1    debug|    vtc = {0x7f7bdf0d3150, Varnish 7.1.1 7cee1c581bead20e88d101ab3d72afb29f14d87a, 0.0},
***  v1    debug|  },
***  v1    debug|  pools = {
***  v1    debug|    pool = 0x7f7bdcc00000 {
***  v1    debug|      nidle = 8,
***  v1    debug|      nthr = 10,
***  v1    debug|      lqueue = 0
***  v1    debug|    },
***  v1    debug|    pool = 0x7f7bdcc00640 {
***  v1    debug|      nidle = 9,
***  v1    debug|      nthr = 10,
***  v1    debug|      lqueue = 0
***  v1    debug|    },
***  v1    debug|  },
***  v1    debug|  
***  v1    debug|  
***  v1    debug|
***  v1    debug|Debug: Child cleanup complete
***  v1    CLI RX  200
**** v1    CLI RX|Panic at: Fri, 16 Sep 2022 14:20:07 GMT
**** v1    CLI RX|Assert error in Req_New(), cache/cache_req.c line 170:
**** v1    CLI RX|  Condition(p < e) not true.
**** v1    CLI RX|version = varnish-7.1.1 revision 7cee1c581bead20e88d101ab3d72afb29f14d87a, vrt api = 15.0
**** v1    CLI RX|ident = Linux,5.15.0-46-generic,x86_64,-junix,-sdefault,-sdefault,-hcritbit,epoll
**** v1    CLI RX|now = 259739.806423 (mono), 1663338007.603864 (real)
**** v1    CLI RX|Backtrace:
**** v1    CLI RX|  0x55cb130c372c: varnishd(+0x5972c) [0x55cb130c372c]
**** v1    CLI RX|  0x55cb1313eed8: varnishd(VAS_Fail+0x18) [0x55cb1313eed8]
**** v1    CLI RX|  0x55cb130c61ab: varnishd(Req_New+0x2bb) [0x55cb130c61ab]
**** v1    CLI RX|  0x55cb13095e0c: varnishd(+0x2be0c) [0x55cb13095e0c]
**** v1    CLI RX|  0x55cb130ea0f2: varnishd(+0x800f2) [0x55cb130ea0f2]
**** v1    CLI RX|  0x55cb130ea684: varnishd(+0x80684) [0x55cb130ea684]
**** v1    CLI RX|  0x7f7bdf7d1ea7: /lib/x86_64-linux-gnu/libpthread.so.0(+0x7ea7) [0x7f7bdf7d1ea7]
**** v1    CLI RX|  0x7f7bdf6f1aef: /lib/x86_64-linux-gnu/libc.so.6(clone+0x3f) [0x7f7bdf6f1aef]
**** v1    CLI RX|argv = {
**** v1    CLI RX|  [0] = \"varnishd\",
**** v1    CLI RX|  [1] = \"-d\",
**** v1    CLI RX|  [2] = \"-n\",
**** v1    CLI RX|  [3] = \"/tmp/vtc.2596.40b16eae/v1\",
**** v1    CLI RX|  [4] = \"-l\",
**** v1    CLI RX|  [5] = \"2m\",
**** v1    CLI RX|  [6] = \"-p\",
**** v1    CLI RX|  [7] = \"auto_restart=off\",
**** v1    CLI RX|  [8] = \"-p\",
**** v1    CLI RX|  [9] = \"syslog_cli_traffic=off\",
**** v1    CLI RX|  [10] = \"-p\",
**** v1    CLI RX|  [11] = \"thread_pool_min=10\",
**** v1    CLI RX|  [12] = \"-p\",
**** v1    CLI RX|  [13] = \"debug=+vtc_mode\",
**** v1    CLI RX|  [14] = \"-p\",
**** v1    CLI RX|  [15] = \"vsl_mask=+Debug\",
**** v1    CLI RX|  [16] = \"-p\",
**** v1    CLI RX|  [17] = \"h2_initial_window_size=1m\",
**** v1    CLI RX|  [18] = \"-p\",
**** v1    CLI RX|  [19] = \"h2_rx_window_low_water=64k\",
**** v1    CLI RX|  [20] = \"-a\",
**** v1    CLI RX|  [21] = \"127.0.0.1:0\",
**** v1    CLI RX|  [22] = \"-M\",
**** v1    CLI RX|  [23] = \"127.0.0.1 36051\",
**** v1    CLI RX|  [24] = \"-P\",
**** v1    CLI RX|  [25] = \"/tmp/vtc.2596.40b16eae/v1/varnishd.pid\",
**** v1    CLI RX|  [26] = \"-p\",
**** v1    CLI RX|  [27] = \"workspace_client=9k\",
**** v1    CLI RX|}
**** v1    CLI RX|pthread.self = 0x7f7bdd0fe700
**** v1    CLI RX|pthread.name = (cache-worker)
**** v1    CLI RX|pthread.attr = {
**** v1    CLI RX|  guard = 4096,
**** v1    CLI RX|  stack_bottom = 0x7f7bdd0eb000,
**** v1    CLI RX|  stack_top = 0x7f7bdd0ff000,
**** v1    CLI RX|  stack_size = 81920,
**** v1    CLI RX|}
**** v1    CLI RX|thr.req = NULL
**** v1    CLI RX|thr.busyobj = NULL
**** v1    CLI RX|thr.worker = 0x7f7bdd0fc590 {
**** v1    CLI RX|  ws = 0x7f7bdd0fc618 {
**** v1    CLI RX|    id = \"wrk\",
**** v1    CLI RX|    {s, f, r, e} = {0x7f7bdd0fbb30, +0, +152, +2040},
**** v1    CLI RX|  },
**** v1    CLI RX|  VCL::method = none,
**** v1    CLI RX|  vmods = {
**** v1    CLI RX|    digest = {0x7f7bdf0d30e0, Varnish 7.1.1 7cee1c581bead20e88d101ab3d72afb29f14d87a, 0.0},
**** v1    CLI RX|    vtc = {0x7f7bdf0d3150, Varnish 7.1.1 7cee1c581bead20e88d101ab3d72afb29f14d87a, 0.0},
**** v1    CLI RX|  },
**** v1    CLI RX|  pools = {
**** v1    CLI RX|    pool = 0x7f7bdcc00000 {
**** v1    CLI RX|      nidle = 8,
**** v1    CLI RX|      nthr = 10,
**** v1    CLI RX|      lqueue = 0
**** v1    CLI RX|    },
**** v1    CLI RX|    pool = 0x7f7bdcc00640 {
**** v1    CLI RX|      nidle = 9,
**** v1    CLI RX|      nthr = 10,
**** v1    CLI RX|      lqueue = 0
**** v1    CLI RX|    },
**** v1    CLI RX|  },
**** v1    CLI RX|  
**** v1    CLI RX|  
**** v1    CLI RX|
---- v1    Unexpected panic
*    top   failure during reset
#    top  TEST ../src/tests/test02.vtc FAILED (0.505) exit=2
make[1]: *** [Makefile:705: ../src/tests/test02.vtc] Error 2
make[1]: *** Waiting for unfinished jobs....
#    top  TEST ../src/tests/test_hex.vtc passed (0.507)
#    top  TEST ../src/tests/test_nullstring.vtc passed (0.507)
#    top  TEST ../src/tests/test01.vtc passed (0.608)
#    top  TEST ../src/tests/test_hash.vtc passed (0.608)
```
</details>
I applied the fix suggested in https://github.com/varnishcache/varnish-cache/issues/3665#issuecomment-895895102 , and it passes tests correctly with v7.1.1, v7.1.0 and v7.0.x.

See varnishcache/varnish-cache#3665 and varnishcache/varnish-cache#3101